### PR TITLE
Better IP handling

### DIFF
--- a/geordi/package.json
+++ b/geordi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geordi",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "server/server.js",
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
Cope with numeric IPs (and ignore reported IP from client, just treat as anonymous and work it out ourselves). Also add fallback for non-Cloudfront/loadbalanced scenarios to just use normal IP field when trying to get client IP. Change Anonymous string to a constant. Bump version.