### PR TITLE
Work around loopback-connector-mysql bug

### DIFF
--- a/geordi/common/models/event.json
+++ b/geordi/common/models/event.json
@@ -5,10 +5,10 @@
   "idInjection": true,
   "indexes": {
     "id_index": {
-      "id": 1
+      "columns": "id"
     },
     "userID_index": {
-      "userID": 1
+      "columns": "userID"
     }
   },
   "properties": {

--- a/geordi/common/models/userseq.json
+++ b/geordi/common/models/userseq.json
@@ -5,11 +5,10 @@
   "idInjection": true,
   "indexes": {
     "userID_index": {
-      "userID": 1
+      "columns": "userID"
     },
     "userID_anonymous_index": {
-      "userID": 1,
-      "anonymous": 1
+      "columns": "userID, anonymous"
     }
   },
   "options": {

--- a/geordi/package.json
+++ b/geordi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geordi",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "server/server.js",
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
Work around loopback-connector-mysql bughttps://github.com/strongloop/loopback-connector-mysql/issues/80 which is causing ER_KEY_COLUMN_DOES_NOT_EXITS: Key column 'undefined' doesn't exist in table